### PR TITLE
Used sys.version_info for Python version checks.

### DIFF
--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -25,9 +25,9 @@ from sphinx.util.console import (  # type: ignore[attr-defined]
 )
 from sphinx.util.osutil import rmtree
 
-try:
-    from contextlib import chdir  # type: ignore[attr-defined]
-except ImportError:
+if sys.version_info >= (3, 11):
+    from contextlib import chdir
+else:
     from sphinx.util.osutil import _chdir as chdir
 
 if TYPE_CHECKING:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 import traceback
 import types
@@ -14,9 +15,9 @@ from sphinx.util import logging
 from sphinx.util.osutil import fs_encoding
 from sphinx.util.typing import NoneType
 
-try:
-    from contextlib import chdir  # type: ignore[attr-defined]
-except ImportError:
+if sys.version_info >= (3, 11):
+    from contextlib import chdir
+else:
     from sphinx.util.osutil import _chdir as chdir
 
 if TYPE_CHECKING:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -15,9 +15,9 @@ from docutils.parsers.rst.states import Inliner
 if TYPE_CHECKING:
     import enum
 
-try:
-    from types import UnionType  # type: ignore[attr-defined] # python 3.10 or above
-except ImportError:
+if sys.version_info >= (3, 10):
+    from types import UnionType
+else:
     UnionType = None
 
 # classes that have incorrect __module__


### PR DESCRIPTION
Mypy understands the use of sys.version_info within if/elif/else statments. See https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks

This allows for the removal of some # type: ignore comments.

Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

